### PR TITLE
fix: apply :global() to whole selector + add strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Pass an object of the following properties
 | `localIdentName` | `{String}` | `"[local]-[hash:base64:6]"` |  A rule using any available token from [webpack interpolateName](https://github.com/webpack/loader-utils#interpolatename) |
 | `includePaths` | `{Array}` | `[]` (Any) | An array of paths to be processed |
 | `getLocalIdent` | `Function` | `undefined`  | Generate the classname by specifying a function instead of using the built-in interpolation |
+| `strict`  | `Boolean` | `false` | When true, an exception is raised when a class is used while not being defined in `<style>`
 
 #### `getLocalIdent`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-preprocess-cssmodules",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/remove.test.js
+++ b/test/remove.test.js
@@ -22,3 +22,16 @@ test('[Shorthand] Remove unused CSS Modules from HTML attribute', async () => {
 
   expect(output).toBe(expectedOutput);
 });
+
+describe('in strict mode', () => {
+  test('Throws an exception', async () => {
+    await expect(compiler({
+      source,
+    }, {
+      localIdentName: '[local]-123456',
+      strict: true,
+    })).rejects.toThrow(
+      'Classname \"blue\" was not found in declared src/App.svelte <style>'
+    );
+  });
+});

--- a/test/replace.test.js
+++ b/test/replace.test.js
@@ -1,7 +1,8 @@
 const compiler = require('./compiler.js');
 
-const source = '<style>.red { color: red; }</style>\n<span class="$style.red">Red</span>';
-const sourceShorthand = '<style>.red { color: red; }</style>\n<span class="$.red">Red</span>';
+const style = '<style>.red { color: red; }</style>';
+const source = style + '\n<span class="$style.red">Red</span>';
+const sourceShorthand = style + '\n<span class="$.red">Red</span>';
 
 test('Generate CSS Modules from HTML attributes, Replace CSS className', async () => {
   const output = await compiler({
@@ -54,4 +55,72 @@ test('[Shorthand] Avoid generated class to end with a hyphen', async () => {
     localIdentName: '[local]-',
   });
   expect(output).toBe('<style>:global(.red) { color: red; }</style>\n<span class="red">Red</span>');
+});
+
+describe('combining multiple classes', () => {
+  const style = '<style>span.red.large:hover { font-size: 20px; } \n.red { color: red; }</style>';
+  const source = style + '\n<span class="$style.red $style.large">Red</span>';
+
+  const expectedStyle =
+    '<style>:global(span.red-123456.large-123456:hover) { font-size: 20px; } \n:global(.red-123456) { color: red; }</style>';
+  const expectedOutput = expectedStyle + '\n<span class="red-123456 large-123456">Red</span>';
+
+  test('Generate CSS Modules from HTML attributes, Replace CSS className', async () => {
+    const output = await compiler(
+      {
+        source,
+      },
+      {
+        localIdentName: '[local]-123456',
+      }
+    );
+
+    expect(output).toBe(expectedOutput);
+  });
+});
+
+describe('using dynamic classes', () => {
+  describe('when matched class is empty', () => {
+    // The parser will identify a class named ''
+    const source =
+      '<style>.red { font-size: 20px; }</style>' + '<span class={`$style.${color}`}>Red</span>';
+
+    test('throws an exception', async () => {
+      await expect(compiler({ source })).rejects.toThrow(
+        'Invalid class name in file src/App.svelte.\nThis usually happens when using dynamic classes with svelte-preprocess-cssmodules.'
+      );
+    });
+  });
+
+  describe('when matched class could be a valid class but does not match any style definition', () => {
+    // The parser will identify a class named 'color'
+    const source =
+      '<style>.colorred { font-size: 20px; }</style>' +
+      '<span class={`$style.color${color}`}>Red</span>';
+
+    it('in strict mode, it throw an exception', async () => {
+      await expect(compiler({ source }, { strict: true })).rejects.toThrow(
+        'Classname "color" was not found in declared src/App.svelte <style>'
+      );
+    });
+
+    // TODO: fix, this is probably not a result one would expect
+    it('in non-strict mode, it removes the resulting class', async () => {
+      const output = await compiler({ source }, { strict: false });
+      expect(output).toEqual(
+        '<style>.colorred { font-size: 20px; }</style><span class={`${color}`}>Red</span>'
+      );
+    });
+  });
+
+  describe('when matched class is an invalid class', () => {
+    // The parser will identify a class named 'color-'
+    const source =
+      '<style>.color-red { font-size: 20px; }</style>' +
+      '<span class={`$style.color-${color}`}>Red</span>';
+
+    it('throws an exception when resulting class is invalid', async () => {
+      await expect(compiler({ source })).rejects.toThrow('Classname "color-" in file src/App.svelte is not valid');
+    });
+  });
 });


### PR DESCRIPTION
Fixing some issues when combining (pseudo)class selectors, ex: `.test.test-2 {}`, `p.test { ... }` , `.test:over { ... }`, etc...
