### PR TITLE
Normalize includePaths

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,13 @@ import { parse } from 'svelte/compiler';
 import type { Ast } from 'svelte/types/compiler/interfaces.d';
 import type { PluginOptions, PreprocessorOptions, PreprocessorResult } from './types';
 import { nativeProcessor, mixedProcessor, scopedProcessor } from './processors';
-import { getLocalIdent, isFileIncluded, hasModuleImports, hasModuleAttribute } from './lib';
+import {
+  getLocalIdent,
+  isFileIncluded,
+  hasModuleImports,
+  hasModuleAttribute,
+  normalizeIncludePaths,
+} from './lib';
 
 const defaultOptions = (): PluginOptions => {
   return {
@@ -21,7 +27,7 @@ const defaultOptions = (): PluginOptions => {
 let pluginOptions: PluginOptions;
 
 const markup = async ({ content, filename }: PreprocessorOptions): Promise<PreprocessorResult> => {
-  const isIncluded = await isFileIncluded(pluginOptions.includePaths, filename);
+  const isIncluded = isFileIncluded(pluginOptions.includePaths, filename);
 
   if (!isIncluded || (!pluginOptions.parseStyleTag && !pluginOptions.parseExternalStylesheet)) {
     return { code: content };
@@ -84,6 +90,11 @@ export default module.exports = (options: Partial<PluginOptions>) => {
     ...defaultOptions(),
     ...options,
   };
+
+  if (pluginOptions.includePaths) {
+    pluginOptions.includePaths = normalizeIncludePaths(pluginOptions.includePaths);
+  }
+
   return {
     markup,
   };

--- a/src/lib/requirement.ts
+++ b/src/lib/requirement.ts
@@ -1,9 +1,19 @@
 import path from 'path';
 import type { Ast } from 'svelte/types/compiler/interfaces.d';
 
+/**
+ * Normalize path by replacing potential backslashes to slashes
+ * @param filepath The file path to normalize
+ * @returns a path using forward slashes
+ */
 const normalizePath = (filepath: string): string =>
   path.sep === '\\' ? filepath.replace(/\\/g, '/') : filepath;
 
+/**
+ * Normalize all included paths
+ * @param paths all paths to be normalized
+ * @returns list of path using forward slashes
+ */
 export const normalizeIncludePaths = (paths: string[]): string[] =>
   paths.map((includePath) => normalizePath(path.resolve(includePath)));
 

--- a/src/lib/requirement.ts
+++ b/src/lib/requirement.ts
@@ -1,32 +1,24 @@
 import path from 'path';
 import type { Ast } from 'svelte/types/compiler/interfaces.d';
 
+const normalizePath = (filepath: string): string =>
+  path.sep === '\\' ? filepath.replace(/\\/g, '/') : filepath;
+
+export const normalizeIncludePaths = (paths: string[]): string[] =>
+  paths.map((includePath) => normalizePath(path.resolve(includePath)));
+
 /**
  * Check if a file requires processing
  * @param includePaths List of allowd paths
  * @param filename the current filename to compare with the paths
  * @returns The permission status
  */
-export const isFileIncluded = async (
-  includePaths: string[],
-  filename: string
-): Promise<boolean> => {
+export const isFileIncluded = (includePaths: string[], filename: string): boolean => {
   if (includePaths.length < 1) {
     return true;
   }
 
-  const isIncluded: boolean = await new Promise((resolve): void => {
-    includePaths.forEach((includePath, index): void => {
-      if (filename.indexOf(path.resolve(includePath)) !== -1) {
-        resolve(true);
-      }
-      if (index === includePaths.length - 1) {
-        resolve(false);
-      }
-    });
-  });
-
-  return isIncluded;
+  return includePaths.some((includePath) => filename.startsWith(includePath));
 };
 
 /**


### PR DESCRIPTION
Fixes #42 by normalizing includePaths to use forward slashes on Windows too.

In addition, filenames are now expected to *start with* an includePath, not only contain it. includePaths are now resolved ahead of time to improve performance.